### PR TITLE
allow passing of arguments to functions executed by the context class loader switcher

### DIFF
--- a/javaloader/JavaLoader.cfc
+++ b/javaloader/JavaLoader.cfc
@@ -104,9 +104,9 @@ Purpose:    Utlitity class for loading Java Classes
 	
 <cffunction name="switchThreadContextClassLoader" hint="Sometimes you will need to switch out the ThreadContextClassLoader with the classloader used by JavaLoader.<br/>
 			It has :
-			switchThreadContextClassLoader(function object, [classLoader=getURLClassLoader()], [struct function arguments])
-			switchThreadContextClassLoader(function name, [classLoader=getURLClassLoader()], [struct function arguments])
-			switchThreadContextClassLoader(object, function name, [classLoader=getURLClassLoader()], [struct function arguments])
+			switchThreadContextClassLoader(function object, [struct function arguments], [classLoader=getURLClassLoader()])
+			switchThreadContextClassLoader(function name, [struct function arguments], [classLoader=getURLClassLoader()])
+			switchThreadContextClassLoader(object, function name, [struct function arguments], [classLoader=getURLClassLoader()])
 			This method can be used in 3 different ways:
 			<ol>
 				<li>Pass it the UDF itself</li>
@@ -120,12 +120,12 @@ Purpose:    Utlitity class for loading Java Classes
 		var Thread = createObject("java", "java.lang.Thread");
 		var currentClassloader = Thread.currentThread().getContextClassLoader();
 		var classLoader = "";
-		
+
 		if (structCount(arguments) == 4) 
 		{	
-			// the last 2 arguments are the classloader and function arguments
-			classLoader = arguments[3];
-			local.funcArgs = arguments[4];	
+			// the last 2 arguments are the function arguments and class loader
+			classLoader = arguments[4];
+			local.funcArgs = arguments[3];
 		} 
 		else if (structCount(arguments) == 3) 
 		{	

--- a/unittests/load/SwitchThreadContextTest.cfc
+++ b/unittests/load/SwitchThreadContextTest.cfc
@@ -71,7 +71,7 @@
 	<cfscript>
 		var mixin = javaloader.switchThreadContextClassLoader;
 		var args = { "arg1" = 1, "arg2" = 2};
-		var result = mixin("returnCurrentClassLoaderAndArguments", javaloader.getURLClassLoader(), args);
+		var result = mixin("returnCurrentClassLoaderAndArguments", args, javaloader.getURLClassLoader());
 		assertSame(javaloader.getURLClassLoader(), result.classLoader);
 		assertStructEquals(args, result.args);
 	</cfscript>
@@ -90,7 +90,7 @@
 	<cfscript>
 		var urlClassLoader = createObject("java", "java.net.URLClassLoader").init(ArrayNew(1));
 		var args = { "arg1" = 1, "arg2" = 2};
-		var result = javaloader.switchThreadContextClassLoader(returnCurrentClassLoaderAndArguments, urlClassLoader, args);
+		var result = javaloader.switchThreadContextClassLoader(returnCurrentClassLoaderAndArguments, args, urlClassLoader);
 		assertSame(urlClassLoader, result.classLoader);
 		assertStructEquals(args, result.args);
 	</cfscript>
@@ -121,7 +121,7 @@
 
 		makePublic(local.object, "returnCurrentClassLoaderAndArguments");
 
-		local.result = javaloader.switchThreadContextClassLoader(local.object, "returnCurrentClassLoaderAndArguments", local.urlClassLoader, local.args);
+		local.result = javaloader.switchThreadContextClassLoader(local.object, "returnCurrentClassLoaderAndArguments", local.args, local.urlClassLoader);
 		assertSame(local.urlClassLoader, local.result.classLoader);
 		assertStructEquals(local.args, local.result.args);
 	</cfscript>


### PR DESCRIPTION
These changes allow you to pass arguments to a function executed by the context class loader switcher helper method.
