### PR TITLE
fixed unscoped variable

### DIFF
--- a/javaloader/JavaLoader.cfc
+++ b/javaloader/JavaLoader.cfc
@@ -478,11 +478,11 @@ Purpose:    Utlitity class for loading Java Classes
 	<cfdirectory action="list" name="qJars" directory="#path#" filter="*.jar" sort="name desc"/>
 	<cfloop query="qJars">
 		<cfscript>
-			libName = ListGetAt(name, 1, "-");
+			libName = ListGetAt(qJars.name, 1, "-");
 			//let's not use the lib's that have the same name, but a lower datestamp
 			if(NOT ListFind(jarList, libName))
 			{
-				ArrayAppend(aJars, path & "/" & name);
+				ArrayAppend(aJars, path & "/" & qJars.name);
 				jarList = ListAppend(jarList, libName);
 			}
 		</cfscript>


### PR DESCRIPTION
unscoped variable in query loop causes error on Railo when strict scoping is used
