### PR TITLE
CF2016 fix where the precedence of arguments results in the parent scope, not the child

### DIFF
--- a/javaloader/JavaProxy.cfc
+++ b/javaloader/JavaProxy.cfc
@@ -121,16 +121,16 @@ Mark Mandel		27/08/2007		Created
 </cffunction>
 
 <cffunction name="_buildArgumentArray" hint="builds an argument array out of the arguments" access="private" returntype="array" output="false">
-	<cfargument name="arguments" hint="the arguments passed through" type="struct" required="Yes">
+	<cfargument name="args" hint="the arguments passed through" type="struct" required="Yes">
 	<cfscript>
-		var len = StructCount(arguments);
+		var len = StructCount(args);
 		var objArray = _getArray().newInstance(_getObjectClass(), len);
 		var counter = 1;
 		var obj = 0;
 
 		for(; counter <= len; counter++)
 		{
-			obj = arguments[counter];
+			obj = args[counter];
 			_getArray().set(objArray, counter - 1, obj);
 		}
 


### PR DESCRIPTION
CF2016 fix where the precedence of arguments results in the parent scope, not the child. 

This caused the arguments structure referenced in _buildArgumentArray to have a StructCount of 1, containing the array of arguments, even if no arguments were passed. Simply renaming the variable to something that isn't a scope variable (args) fixes the issue.